### PR TITLE
Protection to avoid error on unmounted previously focused elements

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -557,7 +557,7 @@ var GlobalConfig = {
   }
 
   function getSectionLastFocusedElement(sectionId) {
-    var lastFocusedElement = _sections[sectionId].lastFocusedElement;
+    var lastFocusedElement = _sections[sectionId] && _sections[sectionId].lastFocusedElement;
     if (!isNavigable(lastFocusedElement, sectionId, true)) {
       return null;
     }


### PR DESCRIPTION
Protect navigation logic while getting the latest focused element but it was already unmounted from DOM